### PR TITLE
Add Feature

### DIFF
--- a/src/Logger/Logger.ts
+++ b/src/Logger/Logger.ts
@@ -42,22 +42,23 @@ export const createLogger = (
 	}
 
 	const logger: iLogger = (...args) => {
-		if (!(outputs.default as iFile).path) {
-			return logToStream(
-				outputs.default as NodeJS.WriteStream,
-				options,
-				'default',
-				args,
-				logger.SYMBOL_MAP
-			);
-		}
-		logToFile(
-			outputs.default as iFile,
-			options,
-			'default',
-			args,
-			logger.SYMBOL_MAP
-		);
+		const outputsArr = Array.isArray(outputs.default)
+			? outputs.default
+			: [outputs.default];
+		console.log(outputsArr.map((elem) => typeof elem));
+		// return;
+		outputsArr.forEach((output) => {
+			if (!(output as iFile).path) {
+				return logToStream(
+					output as NodeJS.WriteStream,
+					options,
+					'default',
+					args,
+					logger.SYMBOL_MAP
+				);
+			}
+			logToFile(output as iFile, options, 'default', args, logger.SYMBOL_MAP);
+		});
 	};
 
 	logger.SYMBOL_MAP = {

--- a/src/Logger/types.d.ts
+++ b/src/Logger/types.d.ts
@@ -4,12 +4,15 @@ export type $Loggable =
 	| (iFile | NodeJS.WriteStream)[];
 
 export interface iLoggerOptions {
-	name: string;
+	loggerName: string;
 	dateFormat?: string;
 	processArgs?: boolean;
 	argProcessor?: (arg: any) => string;
 
 	// Formatting options
+	showName?: boolean;
+	useBracketsForName?: boolean;
+	nameFormatter?: (name: string) => string;
 	showSymbol?: boolean;
 	newLine?: boolean;
 	lineEnding?: string;

--- a/src/helpers/genIndividualLogger.ts
+++ b/src/helpers/genIndividualLogger.ts
@@ -16,16 +16,20 @@ const genIndividualLogger = (
 	SYMBOL_MAP: iSymbolMap
 ): $SubLogger => {
 	return (...args) => {
-		if (!(output as iFile).path) {
-			return logToStream(
-				output as NodeJS.WriteStream,
-				options,
-				logType,
-				args,
-				SYMBOL_MAP
-			);
-		}
-		logToFile(output as iFile, options, logType, args, SYMBOL_MAP);
+		const outputs = Array.isArray(output) ? output : [output];
+		// console.log(outputs.map((elem) => typeof elem));
+		outputs.forEach((output) => {
+			if (!(output as iFile).path) {
+				return logToStream(
+					output as NodeJS.WriteStream,
+					options,
+					logType,
+					args,
+					SYMBOL_MAP
+				);
+			}
+			logToFile(output as iFile, options, logType, args, SYMBOL_MAP);
+		});
 	};
 };
 

--- a/src/helpers/logToOutput/logToFile.ts
+++ b/src/helpers/logToOutput/logToFile.ts
@@ -12,7 +12,7 @@ const logToFile = (
 	args: any[],
 	SYMBOL_MAP: iSymbolMap
 ) => {
-	console.log('logging to file:', file, ...args, `[${logType}]`);
+	console.log(...args, '|', file, `[${logType}]`);
 };
 
 export default logToFile;

--- a/src/helpers/logToOutput/logToStream.ts
+++ b/src/helpers/logToOutput/logToStream.ts
@@ -9,15 +9,19 @@ const logToStream = (
 	SYMBOL_MAP: iSymbolMap
 ) => {
 	const {
-		processArgs,
-		argProcessor,
+		processArgs = false,
+		argProcessor = JSON.stringify,
 		newLine = true,
 		lineEnding = '\n',
 		showSymbol = true,
 		spaceAfterSymbol = true,
+		showName = true,
+		loggerName = 'Logger',
+		useBracketsForName = true,
+		nameFormatter = (name) => name,
 	} = options;
 	const processedOutput = (
-		processArgs ? args.map((argProcessor || JSON.stringify) as any) : args
+		processArgs ? args.map(argProcessor as any) : args
 	).join(' ');
 
 	const symbol = showSymbol
@@ -26,7 +30,12 @@ const logToStream = (
 	const coloredOutput =
 		COLOR_MAP[logType] + processedOutput + COLOR_MAP.default;
 	const endString = newLine ? lineEnding : '';
-	stream.write(symbol + coloredOutput + endString);
+	const name = showName
+		? `${useBracketsForName ? '[' : ''}${nameFormatter(loggerName)}${
+				useBracketsForName ? ']' : ''
+		  } `
+		: '';
+	stream.write(name + symbol + coloredOutput + endString);
 	// console.log(Object.keys(this as any)[0]);
 };
 


### PR DESCRIPTION
Added an option to pass each output as an array of different outputs Example: `[process.stdout, process.stdin, {path: 'path_to_file'}, {path: path_to_another_file}]` The above example will create 4 outputs 2 in the terminal and two in the files