### PR TITLE
Dev/log to file/r

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nandn/logger",
-  "version": "0.3.1",
-  "description": "A module to create instances of logger which will have an output stream (console|file)",
+  "version": "0.4.0",
+  "description": "A module to create instances of logger which will have an output stream (stdout|file)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "jest",
+    "test": "nodemon sandbox/Logger.test.sandbox.ts",
     "ts-node": "ts-node sandbox/Logger.sandbox.ts",
     "prettier": "prettier --write \"src/**/*.ts\"",
     "build": "rm -rf dist && tsc",

--- a/src/Logger/Logger.ts
+++ b/src/Logger/Logger.ts
@@ -49,15 +49,19 @@ function createLoggerArgCleaner(
     case 2: {
       if (isValidOutputs(args[0])) {
         const outputs = args[0];
-        const processedDefault = processOutput(outputs.default, defaultOutput);
+        const processedDefault = processOutput(
+          outputs.default,
+          defaultOutput,
+          args[1]
+        );
         return createLogger(
           {
             default: processedDefault,
-            success: processOutput(outputs.success, processedDefault),
-            info: processOutput(outputs.info, processedDefault),
-            warning: processOutput(outputs.warning, processedDefault),
-            error: processOutput(outputs.error, processedDefault),
-            debug: processOutput(outputs.debug, processedDefault),
+            success: processOutput(outputs.success, processedDefault, args[1]),
+            info: processOutput(outputs.info, processedDefault, args[1]),
+            warning: processOutput(outputs.warning, processedDefault, args[1]),
+            error: processOutput(outputs.error, processedDefault, args[1]),
+            debug: processOutput(outputs.debug, processedDefault, args[1]),
           },
           args[1]
         );

--- a/src/Logger/helpers/getStreamFromFilePath.ts
+++ b/src/Logger/helpers/getStreamFromFilePath.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { iFileOutputOptions } from '../types';
+
+export const getStreamFromFilePath = (
+  filePath: string,
+  options: iFileOutputOptions = {}
+): NodeJS.WriteStream => {
+  // console.log('getStreamFromFilePath', filePath, options);
+  const { clearOnStart = true } = options;
+  // Check if directory exists
+  const dirPath = path.dirname(filePath);
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+
+  const fileExists = fs.existsSync(filePath);
+  if (!fileExists) {
+    fs.writeFileSync(filePath, '');
+    console.log(`Created ${filePath}.`);
+  }
+  let stream: NodeJS.WriteStream;
+  stream = fs.createWriteStream(filePath, {
+    flags: clearOnStart ? 'w' : 'a',
+  }) as any as NodeJS.WriteStream;
+  if (fileExists && clearOnStart) {
+    console.log(`Cleared ${filePath}.`);
+  }
+  return stream;
+};

--- a/src/Logger/helpers/getStreamFromFilePath.ts
+++ b/src/Logger/helpers/getStreamFromFilePath.ts
@@ -7,7 +7,7 @@ export const getStreamFromFilePath = (
   options: iFileOutputOptions = {}
 ): NodeJS.WriteStream => {
   // console.log('getStreamFromFilePath', filePath, options);
-  const { clearOnStart = true } = options;
+  const { clearOnStart = true, showFileClearStatus = true } = options;
   // Check if directory exists
   const dirPath = path.dirname(filePath);
   if (!fs.existsSync(dirPath)) {
@@ -17,14 +17,14 @@ export const getStreamFromFilePath = (
   const fileExists = fs.existsSync(filePath);
   if (!fileExists) {
     fs.writeFileSync(filePath, '');
-    console.log(`Created ${filePath}.`);
+    if (showFileClearStatus) console.log(`Created ${filePath}.`);
   }
   let stream: NodeJS.WriteStream;
   stream = fs.createWriteStream(filePath, {
     flags: clearOnStart ? 'w' : 'a',
   }) as any as NodeJS.WriteStream;
   if (fileExists && clearOnStart) {
-    console.log(`Cleared ${filePath}.`);
+    if (showFileClearStatus) console.log(`Cleared ${filePath}.`);
   }
   return stream;
 };

--- a/src/Logger/helpers/logToOutput/logToFile.ts
+++ b/src/Logger/helpers/logToOutput/logToFile.ts
@@ -1,4 +1,5 @@
 import { $LogType, $SymbolMap, iFileOutput, iLoggerOptions } from '../../types';
+import { logToStream } from './logToStream';
 
 export const logToFile = (
   file: iFileOutput,
@@ -7,6 +8,36 @@ export const logToFile = (
   args: any[],
   SYMBOL_MAP: $SymbolMap
 ): void => {
+  const allArgsArePrimitive = args.every((arg) => {
+    return (
+      typeof arg === 'string' ||
+      typeof arg === 'number' ||
+      typeof arg === 'boolean'
+    );
+  });
+
+  const softOverrides: iLoggerOptions = {
+    // Cause somethings should be logged to a file only if user is sure
+    // This options are overridable by user only if they provide them in file options, not in logger options
+    processArgs: allArgsArePrimitive ? options.processArgs : true,
+    argProcessor: allArgsArePrimitive ? options.argProcessor : JSON.stringify,
+
+    showTime: true,
+  };
+
+  const hardOverrides: iLoggerOptions = {
+    // Cause somethings just shouldn't be logged to a file
+    // This options are not overridable by user
+    colorize: false, // Colors in files? Come on!
+  };
+
+  logToStream(
+    file.target,
+    { ...options, ...softOverrides, ...file.options, ...hardOverrides },
+    logLevel,
+    args,
+    SYMBOL_MAP
+  );
   return;
   options = { ...options, ...file.options };
   console.log(...args, '|', file, `[${logLevel}]`, options);

--- a/src/Logger/helpers/logToOutput/logToFile.ts
+++ b/src/Logger/helpers/logToOutput/logToFile.ts
@@ -8,5 +8,11 @@ export const logToFile = (
   SYMBOL_MAP: $SymbolMap
 ): void => {
   return;
-  console.log(...args, '|', file, `[${logLevel}]`);
+  options = { ...options, ...file.options };
+  console.log(...args, '|', file, `[${logLevel}]`, options);
+  // console.log(
+  //   `FILE: ${file.path} ${
+  //     doesFileExist(file.path) ? 'exists' : 'does not exist'
+  //   }`
+  // );
 };

--- a/src/Logger/helpers/logToOutput/logToStream.ts
+++ b/src/Logger/helpers/logToOutput/logToStream.ts
@@ -24,6 +24,9 @@ export const logToStream = (
     showName = true,
     useBracketsForName = true,
     nameFormatter = (name) => name,
+    //// Time
+    showTime = true,
+    timeFormatter = (time) => time.toDateString(),
     //// Colors
     colorize = true,
   } = options;

--- a/src/Logger/helpers/logToOutput/logToStream.ts
+++ b/src/Logger/helpers/logToOutput/logToStream.ts
@@ -1,5 +1,6 @@
 import { $LogType, $SymbolMap, iLoggerOptions } from '../../types';
 import { COLOR_MAP } from '../../../constants';
+import { formatTime } from '../../../utils/time';
 
 export const logToStream = (
   stream: NodeJS.WriteStream,
@@ -37,22 +38,20 @@ export const logToStream = (
   let name = '';
   if (showName) {
     name = nameFormatter(loggerName, options);
-    name = useBracketsForName
-      ? `[${name}]` + (spaceAfterName ? ' ' : '')
-      : name;
+    name = useBracketsForName ? `[${name}]` : name;
+    name = spaceAfterName ? name + ' ' : name;
   }
 
   let time = '';
   if (showTime) {
     if (typeof timeFormatter === 'string') {
-      time = new Date().toLocaleString(timeFormatter);
+      time = formatTime(new Date(), timeFormatter);
     } else {
       time = showTime ? timeFormatter(new Date(), options) : '';
     }
     // time = time.trim();
-    time = useBracketsForTime
-      ? `[${time}]` + (spaceAfterTime ? ' ' : '')
-      : time;
+    time = useBracketsForTime ? `[${time}]` : time;
+    time = spaceAfterTime ? time + ' ' : time;
   }
 
   let symbolStr = '';

--- a/src/Logger/helpers/logToOutput/logToStream.ts
+++ b/src/Logger/helpers/logToOutput/logToStream.ts
@@ -24,29 +24,52 @@ export const logToStream = (
     showName = true,
     useBracketsForName = true,
     nameFormatter = (name) => name,
+    spaceAfterName = true,
     //// Time
-    showTime = true,
+    showTime = false,
     timeFormatter = (time) => time.toDateString(),
+    useBracketsForTime = true,
+    spaceAfterTime = true,
     //// Colors
     colorize = true,
   } = options;
 
+  let name = '';
+  if (showName) {
+    name = nameFormatter(loggerName, options);
+    name = useBracketsForName
+      ? `[${name}]` + (spaceAfterName ? ' ' : '')
+      : name;
+  }
+
+  let time = '';
+  if (showTime) {
+    if (typeof timeFormatter === 'string') {
+      time = new Date().toLocaleString(timeFormatter);
+    } else {
+      time = showTime ? timeFormatter(new Date(), options) : '';
+    }
+    // time = time.trim();
+    time = useBracketsForTime
+      ? `[${time}]` + (spaceAfterTime ? ' ' : '')
+      : time;
+  }
+
+  let symbolStr = '';
+  if (showSymbol) {
+    symbolStr =
+      (symbol || SYMBOL_MAP[logLevel]) + (spaceAfterSymbol ? ' ' : '');
+  }
+
   const processedOutput = (
     processArgs ? args.map(argProcessor as any) : args
   ).join(' ');
-
-  const symbolStr = showSymbol
-    ? (symbol || SYMBOL_MAP[logLevel]) + (spaceAfterSymbol ? ' ' : '')
-    : '';
   const coloredOutput =
     (colorize ? COLOR_MAP[logLevel] : '') +
     processedOutput +
     (colorize ? COLOR_MAP.default : '');
+
   const endString = newLine ? lineEnding : '';
-  const name = showName
-    ? `${useBracketsForName ? '[' : ''}${nameFormatter(loggerName, options)}${
-        useBracketsForName ? ']' : ''
-      } `
-    : '';
-  stream.write(name + symbolStr + coloredOutput + endString);
+
+  stream.write(name + time + symbolStr + coloredOutput + endString);
 };

--- a/src/Logger/helpers/processOutput.ts
+++ b/src/Logger/helpers/processOutput.ts
@@ -1,13 +1,18 @@
-import { $Output } from '../types';
-import { isWriteStream } from '../../utils/fs';
+import { $Output, iLoggerOptions } from '../types';
+import { isWriteStream } from '../typeGuards';
+import { getStreamFromFilePath } from './getStreamFromFilePath';
 
 export const processOutput = (
   output: any,
-  processedDefault: any
+  processedDefault: $Output | $Output[],
+  options: iLoggerOptions = {}
 ): $Output | $Output[] => {
   if (!output) return processedDefault;
   if (Array.isArray(output)) {
-    return (output as $Output[]).map(processOutput) as $Output[];
+    // return (output as $Output[]).map(processOutput) as $Output[];
+    return (output as $Output[]).map((output) => {
+      return processOutput(output, processedDefault, options);
+    }) as $Output[];
   }
 
   if (isWriteStream(output) || output === 'console') {
@@ -22,6 +27,7 @@ export const processOutput = (
     return {
       type: 'FILE',
       path: output,
+      target: getStreamFromFilePath(output, options),
       options: {},
     };
   }
@@ -30,6 +36,10 @@ export const processOutput = (
     return {
       type: 'FILE',
       path: output.path,
+      target: getStreamFromFilePath(output.path, {
+        ...options,
+        ...(output.options || {}),
+      }),
       options: output.options || {},
     };
   }

--- a/src/Logger/typeGuards.ts
+++ b/src/Logger/typeGuards.ts
@@ -1,6 +1,11 @@
 import log from '../utils/log';
 import { $Output, $Outputs, iTerminalOutput } from './types';
-import { isValidPath, isWriteStream } from '../utils/fs';
+import { isValidPath } from '../utils/fs';
+import { Writable } from 'stream';
+
+export const isWriteStream = (stream: any): stream is NodeJS.WriteStream => {
+  return stream && stream instanceof Writable;
+};
 
 export function isValidOutputs(arg: any): arg is $Outputs {
   if (typeof arg !== 'object' || arg === null) {

--- a/src/Logger/types.ts
+++ b/src/Logger/types.ts
@@ -10,11 +10,12 @@ export type $LogType =
   | 'debug';
 
 export interface iFileOutputOptions extends iLoggerOptions {
-  resetOnStart?: boolean;
+  clearOnStart?: boolean;
 }
 export interface iFileOutput {
   type: 'FILE';
   path: string;
+  target: NodeJS.WriteStream;
   options: iFileOutputOptions;
 }
 
@@ -60,6 +61,9 @@ export interface iLoggerOptions {
     [key in $LogType]?: string;
   };
   spaceAfterSymbol?: boolean;
+
+  // File options
+  clearOnStart?: boolean;
 }
 
 export type $SubLogger = (...args: any[]) => void;

--- a/src/Logger/types.ts
+++ b/src/Logger/types.ts
@@ -45,7 +45,7 @@ export interface iLoggerOptions {
 
   //// Time
   showTime?: boolean;
-  timeFormatter?: (time: Date, options?: iLoggerOptions) => string;
+  timeFormatter?: (time: Date, options: iLoggerOptions) => string;
 
   //// Line ending
   newLine?: boolean;

--- a/src/Logger/types.ts
+++ b/src/Logger/types.ts
@@ -44,10 +44,13 @@ export interface iLoggerOptions {
   showName?: boolean;
   useBracketsForName?: boolean;
   nameFormatter?: (name: string, options: iLoggerOptions) => string;
+  spaceAfterName?: boolean;
 
   //// Time
   showTime?: boolean;
-  timeFormatter?: (time: Date, options: iLoggerOptions) => string;
+  timeFormatter?: string | ((time: Date, options: iLoggerOptions) => string);
+  useBracketsForTime?: boolean;
+  spaceAfterTime?: boolean;
 
   //// Line ending
   newLine?: boolean;

--- a/src/Logger/types.ts
+++ b/src/Logger/types.ts
@@ -37,6 +37,8 @@ export interface iLoggerOptions {
   processArgs?: boolean;
   argProcessor?: (arg: any) => string;
 
+  showFileClearStatus?: boolean; // Informs the user if a file was cleared on start
+
   // Formatting options
   //// Name
   showName?: boolean;

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,10 +1,4 @@
-const { Writable } = require('stream');
-// const path = require('path');
 import path from 'path';
-
-export const isWriteStream = (stream: any): stream is NodeJS.WriteStream => {
-  return stream && stream instanceof Writable;
-};
 
 export const isValidPath = (filePath: string): boolean => {
   const parsedPath = path.parse(filePath);

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,63 @@
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+const DAYS = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+const REGEX_MAP = {
+  YYYY: (time: Date) => time.getFullYear().toString(),
+  YY: (time: Date) => time.getFullYear().toString().slice(-2),
+  MMMM: (time: Date) => MONTHS[time.getMonth()].toUpperCase(),
+  Mmmm: (time: Date) => MONTHS[time.getMonth()],
+  mmmm: (time: Date) => MONTHS[time.getMonth()].toLowerCase(),
+  MMM: (time: Date) => MONTHS[time.getMonth()].slice(0, 3).toUpperCase(),
+  Mmm: (time: Date) => MONTHS[time.getMonth()].slice(0, 3),
+  mmm: (time: Date) => MONTHS[time.getMonth()].slice(0, 3).toLowerCase(),
+  MM: (time: Date) => time.getMonth().toString().padStart(2, '0'),
+  M: (time: Date) => time.getMonth().toString(),
+  DDDD: (time: Date) => DAYS[time.getDay()].toUpperCase(),
+  Dddd: (time: Date) => DAYS[time.getDay()],
+  dddd: (time: Date) => DAYS[time.getDay()].toLowerCase(),
+  DDD: (time: Date) => DAYS[time.getDay()].slice(0, 3).toUpperCase(),
+  Ddd: (time: Date) => DAYS[time.getDay()].slice(0, 3),
+  ddd: (time: Date) => DAYS[time.getDay()].slice(0, 3).toLowerCase(),
+  DD: (time: Date) => time.getDate().toString().padStart(2, '0'),
+  D: (time: Date) => time.getDate().toString(),
+  HH: (time: Date) => time.getHours().toString().padStart(2, '0'),
+  H: (time: Date) => time.getHours().toString(),
+  hh: (time: Date) => (time.getHours() % 12).toString().padStart(2, '0'),
+  h: (time: Date) => (time.getHours() % 12).toString(),
+  A: (time: Date) => (time.getHours() >= 12 ? 'PM' : 'AM'),
+  a: (time: Date) => (time.getHours() >= 12 ? 'pm' : 'am'),
+  mm: (time: Date) => time.getMinutes().toString().padStart(2, '0'),
+  m: (time: Date) => time.getMinutes().toString(),
+  ss: (time: Date) => time.getSeconds().toString().padStart(2, '0'),
+  s: (time: Date) => time.getSeconds().toString(),
+  SSS: (time: Date) => time.getMilliseconds().toString().padStart(3, '0'),
+  S: (time: Date) => time.getMilliseconds().toString(),
+};
+const DATE_TIME_REGEX = new RegExp(Object.keys(REGEX_MAP).join('|'), 'g');
+export const formatTime = (time: Date, formatString: string): string => {
+  return formatString.replace(DATE_TIME_REGEX, (match) =>
+    (REGEX_MAP as any)[match](time)
+  );
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,10 @@
   "compilerOptions": {
     "target": "ES2015",
     "module": "commonjs",
+    // "module": "esnext",
     "outDir": "./dist",
     "declaration": true,
-    "sourceMap": true,
+    // "sourceMap": true,
     "removeComments": true,
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Added the functionality to log time along with the contents

> Note: Just like most other functionalities, this is also optional, but enabled by default for files and disabled by default for stdout | console

#### Example
```javascript
{
  ...
  showTime: boolean, // true | false
  timeFormatter: string | Function // Function takes Date as argument and should return a formatted string as user intended whereas string is just a format of date ('YY-MM-DD' or 'HH:MM A')
  ...
}
```
### Addresses the following issues
- https://github.com/NandanGit/logger/issues/19
- https://github.com/NandanGit/logger/issues/38