### PR TITLE
Add period file logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nandn/logger",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A module to create instances of logger which will have an output stream (stdout|file)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Logger/helpers/getStreamFromFilePath.ts
+++ b/src/Logger/helpers/getStreamFromFilePath.ts
@@ -1,17 +1,63 @@
 import fs from 'fs';
 import path from 'path';
-import { iFileOutputOptions } from '../types';
+import { iFileOutputOptions, iFileOutputTarget } from '../types';
+import { resolvePeriod } from './resolvePeriod';
+import {
+  DEFAULT_FILE_NAME_FORMATTER,
+  DEFAULT_PERIOD_START,
+} from '../../constants';
+import { formatTime } from '../../utils/time';
 
-export const getStreamFromFilePath = (
+export interface iCreateStreamOutput {
+  stream: NodeJS.WriteStream;
+  expiresAt: Date | null;
+}
+
+const createStream = (
   filePath: string,
-  options: iFileOutputOptions = {}
-): NodeJS.WriteStream => {
+  options: iFileOutputOptions,
+  isPeriodic: boolean
+): iCreateStreamOutput => {
+  // Declarations
   // console.log('getStreamFromFilePath', filePath, options);
-  const { clearOnStart = true, showFileClearStatus = true } = options;
+  const { clearOnStart = false, showFileClearStatus = true } = options;
+  let stream: NodeJS.WriteStream;
+  let expiresAt: Date | null = null;
   // Check if directory exists
-  const dirPath = path.dirname(filePath);
+  const dirPath = isPeriodic ? filePath : path.dirname(filePath);
+  console.log('dirPath', dirPath);
   if (!fs.existsSync(dirPath)) {
     fs.mkdirSync(dirPath, { recursive: true });
+  }
+  if (isPeriodic) {
+    const {
+      period = 3600000,
+      periodStart = DEFAULT_PERIOD_START,
+      fileNameFormatter = DEFAULT_FILE_NAME_FORMATTER,
+      takeFullNameFromFileNameFormatter = false,
+      takeExtensionFromFileNameFormatter = true,
+    } = options;
+    const { localStart, localEnd } = resolvePeriod(period, periodStart);
+    expiresAt = localEnd;
+    let fileName: string;
+    if (typeof fileNameFormatter === 'string') {
+      fileName = `${formatTime(localStart, fileNameFormatter)} - ${formatTime(
+        localEnd,
+        fileNameFormatter
+      )}.log`;
+    } else {
+      if (takeFullNameFromFileNameFormatter) {
+        fileName =
+          fileNameFormatter(localStart, localEnd) +
+          (takeExtensionFromFileNameFormatter ? '.log' : '');
+      } else {
+        fileName = `${fileNameFormatter(
+          localStart,
+          localEnd
+        )} - ${fileNameFormatter(localEnd, localStart)}.log`;
+      }
+    }
+    filePath = path.join(dirPath, fileName);
   }
 
   const fileExists = fs.existsSync(filePath);
@@ -19,12 +65,49 @@ export const getStreamFromFilePath = (
     fs.writeFileSync(filePath, '');
     if (showFileClearStatus) console.log(`Created ${filePath}.`);
   }
-  let stream: NodeJS.WriteStream;
+
   stream = fs.createWriteStream(filePath, {
     flags: clearOnStart ? 'w' : 'a',
   }) as any as NodeJS.WriteStream;
+
   if (fileExists && clearOnStart) {
     if (showFileClearStatus) console.log(`Cleared ${filePath}.`);
   }
-  return stream;
+
+  return { stream, expiresAt };
+};
+
+export const getStreamFromFilePath = (
+  filePath: string,
+  options: iFileOutputOptions = {}
+): iFileOutputTarget => {
+  // console.log('getStreamFromFilePath', filePath, options);
+  // Check if the file output should be periodic
+  let stream: NodeJS.WriteStream;
+  let expiresAt: Date | null = null;
+  if (options.periodic) {
+    console.log('Periodic');
+    const streamResponse = createStream(filePath, options, true);
+    stream = streamResponse.stream;
+    expiresAt = streamResponse.expiresAt as Date;
+  } else {
+    console.log('Not periodic');
+    const streamResponse = createStream(filePath, options, false);
+    stream = streamResponse.stream;
+  }
+
+  const updateStream = () => {
+    console.log('Updating stream');
+    const streamResponse = createStream(filePath, options, true);
+    result.stream = streamResponse.stream;
+    result.expiresAt = streamResponse.expiresAt as Date;
+  };
+
+  const result: iFileOutputTarget = {
+    stream,
+    updateStream,
+    expiresAt,
+  };
+
+  return result;
 };

--- a/src/Logger/helpers/logToOutput/logToFile.ts
+++ b/src/Logger/helpers/logToOutput/logToFile.ts
@@ -1,3 +1,4 @@
+import { formatTime } from '../../../utils/time';
 import { $LogType, $SymbolMap, iFileOutput, iLoggerOptions } from '../../types';
 import { logToStream } from './logToStream';
 
@@ -31,19 +32,23 @@ export const logToFile = (
     colorize: false, // Colors in files? Come on!
   };
 
-  logToStream(
-    file.target,
-    { ...options, ...softOverrides, ...file.options, ...hardOverrides },
-    logLevel,
-    args,
-    SYMBOL_MAP
-  );
-  return;
-  options = { ...options, ...file.options };
-  console.log(...args, '|', file, `[${logLevel}]`, options);
-  // console.log(
-  //   `FILE: ${file.path} ${
-  //     doesFileExist(file.path) ? 'exists' : 'does not exist'
-  //   }`
-  // );
+  const combinedOptions = {
+    ...options,
+    ...softOverrides,
+    ...file.options,
+    ...hardOverrides,
+  };
+
+  // console.log('combinedOptions', combinedOptions);
+  if (combinedOptions.period) {
+    // Check if file has expired
+    if (
+      file.target.expiresAt &&
+      file.target.expiresAt.getTime() < new Date().getTime()
+    ) {
+      file.target.updateStream();
+    }
+  }
+
+  logToStream(file.target.stream, combinedOptions, logLevel, args, SYMBOL_MAP);
 };

--- a/src/Logger/helpers/processOptions.ts
+++ b/src/Logger/helpers/processOptions.ts
@@ -1,0 +1,21 @@
+import { parsePeriod } from '../../utils/time';
+import {
+  iFileOutputOptions,
+  iFileOutputOptionsArg,
+  iLoggerOptions,
+} from '../types';
+
+export const processFileOptions = (
+  options: iFileOutputOptionsArg | iLoggerOptions = {}
+): iFileOutputOptions => {
+  let { period } = options as iFileOutputOptionsArg;
+  if (period) {
+    period = parsePeriod(period);
+  }
+  const result: iFileOutputOptions = {
+    ...options,
+    period: period as number | undefined,
+  };
+
+  return result;
+};

--- a/src/Logger/helpers/processOutput.ts
+++ b/src/Logger/helpers/processOutput.ts
@@ -1,6 +1,7 @@
 import { $Output, iLoggerOptions } from '../types';
 import { isWriteStream } from '../typeGuards';
 import { getStreamFromFilePath } from './getStreamFromFilePath';
+import { processFileOptions } from './processOptions';
 
 export const processOutput = (
   output: any,
@@ -24,23 +25,25 @@ export const processOutput = (
   }
 
   if (typeof output === 'string') {
+    const processedOptions = processFileOptions(options);
     return {
       type: 'FILE',
       path: output,
-      target: getStreamFromFilePath(output, options),
+      target: getStreamFromFilePath(output, processedOptions),
       options: {},
     };
   }
 
   if (output.type === 'FILE') {
+    const processedOptions = processFileOptions({
+      ...options,
+      ...(output.options || {}),
+    });
     return {
       type: 'FILE',
       path: output.path,
-      target: getStreamFromFilePath(output.path, {
-        ...options,
-        ...(output.options || {}),
-      }),
-      options: output.options || {},
+      target: getStreamFromFilePath(output.path, processedOptions),
+      options: processFileOptions(output.options || {}),
     };
   }
 

--- a/src/Logger/helpers/resolvePeriod.ts
+++ b/src/Logger/helpers/resolvePeriod.ts
@@ -1,0 +1,17 @@
+interface iResolvePeriodOutput {
+  localStart: Date;
+  localEnd: Date;
+}
+
+export const resolvePeriod = (
+  period: number,
+  periodStart: Date
+): iResolvePeriodOutput => {
+  const nowTime = new Date().getTime();
+  const periodStartTime = periodStart.getTime();
+  const localStart = nowTime - ((nowTime - periodStartTime) % period);
+  return {
+    localStart: new Date(localStart),
+    localEnd: new Date(localStart + period),
+  };
+};

--- a/src/Logger/types.ts
+++ b/src/Logger/types.ts
@@ -11,11 +11,24 @@ export type $LogType =
 
 export interface iFileOutputOptions extends iLoggerOptions {
   clearOnStart?: boolean;
+  periodic?: boolean;
+  period?: number;
+  periodStart?: Date;
+  periodEnd?: Date;
+  fileNameFormatter?: string | ((localStart: Date, localEnd: Date) => string);
+  takeFullNameFromFileNameFormatter?: boolean;
+  takeExtensionFromFileNameFormatter?: boolean;
+}
+
+export interface iFileOutputTarget {
+  stream: NodeJS.WriteStream;
+  updateStream: () => void;
+  expiresAt: Date | null;
 }
 export interface iFileOutput {
   type: 'FILE';
   path: string;
-  target: NodeJS.WriteStream;
+  target: iFileOutputTarget;
   options: iFileOutputOptions;
 }
 
@@ -93,10 +106,14 @@ export type $SymbolMap = {
   [key in $LogType]: string;
 };
 
+export interface iFileOutputOptionsArg
+  extends Omit<iFileOutputOptions, 'period'> {
+  period?: number | string;
+}
 export interface iFileOutputArg {
   type: 'FILE';
   path: string;
-  options?: iFileOutputOptions;
+  options?: iFileOutputOptionsArg;
 }
 
 export interface iTerminalOutputArg {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,3 +15,24 @@ export const DEFAULT_SYMBOLS = {
   error: '❌',
   debug: '🐞',
 };
+
+export const DEFAULT_PERIOD_START = new Date(-19800000);
+
+export const DEFAULT_FILE_NAME_FORMATTER = (
+  localStart: Date,
+  localEnd: Date,
+  fullName: boolean = false
+): string => {
+  const start = localStart
+    .toLocaleString('in')
+    .replace(',', '')
+    .replace(/\//g, '-');
+  if (fullName) {
+    const end = localEnd
+      .toLocaleString('in')
+      .replace(',', '')
+      .replace(/\//g, '-');
+    return `${start} - ${end}`;
+  }
+  return start;
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -61,3 +61,43 @@ export const formatTime = (time: Date, formatString: string): string => {
     (REGEX_MAP as any)[match](time)
   );
 };
+
+export const parsePeriod = (period: string | number): number => {
+  if (typeof period === 'number') return period;
+  const regex =
+    /(\d+)\s*(d|day?|days?|h|hr?|hrs?|hours?|m|min?|mins?|minutes?)/gi;
+  const matches = period.match(regex);
+  if (!matches) {
+    throw new Error('Invalid period format');
+  }
+
+  const periodInMilliseconds = matches.reduce((acc, match) => {
+    const [, value = '', unit = ''] = match.match(/(\d+)\s*(\w+)/i) || [];
+    if (!value || !unit) {
+      throw new Error('Invalid period format');
+    }
+
+    switch (unit.toLowerCase()) {
+      case 'd':
+      case 'day':
+      case 'days':
+        return acc + parseInt(value, 10) * 24 * 60 * 60 * 1000; // days to milliseconds
+      case 'h':
+      case 'hr':
+      case 'hrs':
+      case 'hour':
+      case 'hours':
+        return acc + parseInt(value, 10) * 60 * 60 * 1000; // hours to milliseconds
+      case 'm':
+      case 'min':
+      case 'mins':
+      case 'minute':
+      case 'minutes':
+        return acc + parseInt(value, 10) * 60 * 1000; // minutes to milliseconds
+      default:
+        throw new Error(`Unknown unit "${unit}" in period: ${period}`);
+    }
+  }, 0);
+
+  return periodInMilliseconds;
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -55,9 +55,15 @@ const REGEX_MAP = {
   SSS: (time: Date) => time.getMilliseconds().toString().padStart(3, '0'),
   S: (time: Date) => time.getMilliseconds().toString(),
 };
-const DATE_TIME_REGEX = new RegExp(Object.keys(REGEX_MAP).join('|'), 'g');
+
+const REGEX_STR = `(?:\\[.*?\\])|(?:${Object.keys(REGEX_MAP).join('|')})`;
+const DATE_TIME_REGEX = new RegExp(REGEX_STR, 'g');
 export const formatTime = (time: Date, formatString: string): string => {
-  return formatString.replace(DATE_TIME_REGEX, (match) =>
-    (REGEX_MAP as any)[match](time)
-  );
+  return formatString.replace(DATE_TIME_REGEX, (match) => {
+    if (match.startsWith('[') && match.endsWith(']')) {
+      return match.slice(1, -1);
+    } else {
+      return (REGEX_MAP as any)[match](time);
+    }
+  });
 };


### PR DESCRIPTION
## Periodic files support
> Let's imagine our user want to neatly separate log files.
> Let's say they want a new log file everyday
> Now changing the log file path everyday when you start working is not ideal right

### We don't have to imagine anymore
> With this update we are introducing a feature that enables the user to simply achieve this functionality by adding a `period` property to the file options and setting the `periodical` to `true`

> `period` accepts both `number` and `string` types
> > If you are passing a `number` it is assumed that the `period` will be in milliseconds
>
> > If you are passing a `string` it can be of the following forms
> > > `1d` one day
> >
> > > `1day` one day
> >
> > > `1day` one day
> >
> > > `6d` six days
> >
> > > `3days` three days
> >
> > > `6 hr` six hours
> >
> > > `8 hours` eight hours
> >
> > > `5hrs` five hours
> >
> > > `21 hrs` twenty one hours
> >
> > > `1d 6hrs` one day six hours (I know I know, you don't have to thank me 😌)
> >
> > > You can do all this shenanigans with `min`, `minutes`, `mins` but not with `seconds`
> > >
> > > `seconds` is out of the picture cause come on! who creates a new log file every few seconds
> > >
> > > Okay Okay! if you absolutely need to create a file every few seconds just pass the period as milliseconds to the `period` property instead of a string

This PR
- Extends #45 
- Closes #20 
- Closes #43 